### PR TITLE
Support CUI on 24bit color terminal

### DIFF
--- a/colors/japanesque.vim
+++ b/colors/japanesque.vim
@@ -34,6 +34,7 @@ function! s:hi(group, highlight_args) abort
   if !has_key(a:highlight_args, 'gui')
     let a:highlight_args.gui = 'none'
   endif
+  let a:highlight_args.cterm = a:highlight_args.gui
   let attrs = map(items(a:highlight_args), "v:val[0] . '=' . v:val[1]")
   let args = ['highlight', a:group] + attrs
   execute join(args, ' ')


### PR DESCRIPTION
Japanesque is beautiful. However, it doesn't work well on 24bit color terminals.

When `termguicolors` option is set on them, vim uses `guifg` and `guibg` instead of `ctermfg` and `ctermbg`, but not use `gui`. Thus, the `cterm` is used.

I fixed it to assign the value of `gui` to `cterm` as well. It may not be necessary when CUI is formally supported.

For `termguicolors` option, see: http://vim-jp.org/vimdoc-ja/options.html#'termguicolors'.