### PR TITLE
Fix conceal

### DIFF
--- a/colors/japanesque.vim
+++ b/colors/japanesque.vim
@@ -80,7 +80,7 @@ call s:hi('PreProc',    { 'guifg': s:dark_green })
 call s:hi('Type',       { 'guifg': s:yellow })
 call s:hi('Identifier', { 'guifg': s:purple })
 call s:hi('Function',   { 'guifg': s:green })
-call s:hi('Conceal',    { 'guifg': s:dark_gray })
+call s:hi('Conceal',    { 'guifg': s:dark_gray, 'guibg': 'NONE' })
 call s:hi('Special',    { 'guifg': s:yellow })
 call s:hi('Title',      { 'guifg': s:purple })
 


### PR DESCRIPTION
I guess you expect `Conceal` to be `guifg=#828282 guibg=NONE`. However, my MacVim+KaoriYa(CUI) computes below.

```
:highlight Conceal
Conceal        xxx ctermfg=7 ctermbg=242 guifg=#828282 guibg=DarkGrey
```

So I fixed `Conceal` to have no `guibg`.